### PR TITLE
Remove default imports

### DIFF
--- a/lib/k8s-watcher.js
+++ b/lib/k8s-watcher.js
@@ -4,10 +4,10 @@
  * Copyright 2023 AMRC
  */
 
-import util     from "util";
+import * as util    from "util";
 
-import imm      from "immutable";
-import rx       from "rxjs";
+import * as imm     from "immutable";
+import * as rx      from "rxjs";
 
 import { forever }  from "./util.js";
 

--- a/lib/k8s-watcher.js
+++ b/lib/k8s-watcher.js
@@ -132,6 +132,7 @@ export class K8sWatcher {
     }
 }
 
-export function k8s_watch (opts) {
+export function k8sWatch (opts) {
     return new K8sWatcher(opts).track_objects(opts);
 }
+export { k8sWatch as k8s_watch };

--- a/lib/starts-stops.js
+++ b/lib/starts-stops.js
@@ -4,8 +4,8 @@
  * Copyright 2024 AMRC
  */
 
-import imm  from "immutable";
-import rx   from "rxjs";
+import * as imm     from "immutable";
+import * as rx      from "rxjs";
 
 /* Accepts a sequence of Immutable.Sets. Tracks the items in these sets,
  * and picks up when items appear and when items disappear. Returns two

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,6 +6,13 @@
 
 import * as rx  from "rxjs";
 
+/* This will be in RxJS 8 as rx.rx. This is the final result of waiting
+ * for suitable JS pipe syntax that never came... */
+function rx_rx (src, ...pipe) {
+    return rx.pipe(...pipe)(rx.from(src));
+}
+export { rx_rx as rx };
+
 export function log_observer (log, label) {
     return {
         next:       v => log("NEXT %s: %o", label, v),
@@ -62,4 +69,15 @@ export function shareLatest (...args) {
          * restart our source. */
         resetOnRefCountZero: () => rx.timer(1000),   
     });
+}
+
+/* Emit nulls after each time interval, with random jitter. */
+export function jitterInterval (each, jitter) {
+    return rx_rx(
+        rx.of(null),
+        rx.repeat({ 
+            delay: () => rx.timer(each + Math.random()*jitter),
+        }),
+        rx.skip(1),
+    );
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,19 +13,21 @@ function rx_rx (src, ...pipe) {
 }
 export { rx_rx as rx };
 
-export function log_observer (log, label) {
+export function logObserver (log, label) {
     return {
         next:       v => log("NEXT %s: %o", label, v),
         error:      e => log("ERROR %s: %o", label, e),
         complete:   () => log("COMPLETE %s", label),
     };
 }
+export { logObserver as log_observer };
 
-export const console_observer = log_observer.bind(null, console.log);
+export const consoleObserver = logObserver.bind(null, console.log);
+export { consoleObserver as console_observer };
 
 /* Retry with backoff. Logs caught errors to the optional log function.
  * Retry delay defaults to 5s and will back off to 64*. */
-export function retry_backoff (delay, log) {
+export function retryBackoff (delay, log) {
     delay ??= 5000;
     log ??= (e => {});
 
@@ -38,6 +40,7 @@ export function retry_backoff (delay, log) {
         resetOnSuccess: true,
     });
 }
+export { retryBackoff as retry_backoff };
 
 export class StoppedError extends Error { }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -50,7 +50,7 @@ export function forever (...args) {
     return rx.pipe(
         rx.concatWith(rx.throwError(() => 
             new StoppedError("Observable completed unexpectedly"))),
-        retry_backoff(...args),
+        retryBackoff(...args),
     );
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,7 +4,7 @@
  * Copyright 2023 AMRC
  */
 
-import rx from "rxjs";
+import * as rx  from "rxjs";
 
 export function log_observer (log, label) {
     return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amrc-factoryplus/rx-util",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "lib/index.js",
   "type": "module",


### PR DESCRIPTION
* Remove default imports, they are causing problems with bundlers.
* Export two more small utility functions.
* Rename to camelCase convention throughout, with compat exports.